### PR TITLE
Add jellyfin to the Caddyfile automatically

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -63,6 +63,21 @@ https://mail.{\$NC_DOMAIN}:443 {
 CADDY
 fi
 
+if [ -n "$(dig A +short nextcloud-aio-jellyfin)" ] && ! grep -q nextcloud-aio-jellyfin /Caddyfile; then
+    cat << CADDY >> /Caddyfile
+https://jellyfin.{\$NC_DOMAIN}:443 {
+    reverse_proxy nextcloud-aio-jellyfin:8096
+
+    # TLS options
+    tls {
+        issuer acme {
+            disable_http_challenge
+        }
+    }
+}
+CADDY
+fi
+
 mkdir -p /data/caddy-imports
 if ! grep -q "/data/caddy-imports" /Caddyfile; then
     echo 'import /data/caddy-imports/*' >> /Caddyfile

--- a/start.sh
+++ b/start.sh
@@ -65,7 +65,7 @@ fi
 
 if [ -n "$(dig A +short nextcloud-aio-jellyfin)" ] && ! grep -q nextcloud-aio-jellyfin /Caddyfile; then
     cat << CADDY >> /Caddyfile
-https://jellyfin.{\$NC_DOMAIN}:443 {
+https://media.{\$NC_DOMAIN}:443 {
     reverse_proxy nextcloud-aio-jellyfin:8096
 
     # TLS options

--- a/start.sh
+++ b/start.sh
@@ -66,6 +66,7 @@ fi
 if [ -n "$(dig A +short nextcloud-aio-jellyfin)" ] && ! grep -q nextcloud-aio-jellyfin /Caddyfile; then
     cat << CADDY >> /Caddyfile
 https://media.{\$NC_DOMAIN}:443 {
+    # import GEOFILTER
     reverse_proxy nextcloud-aio-jellyfin:8096
 
     # TLS options


### PR DESCRIPTION
This follows the Pull Request https://github.com/nextcloud/all-in-one/pull/4267.

This adds a Jellyfin rule in the Caddyfile to allow remote access to the Jellyfin instance with SSL.

I didn't test it, since this would include pushing a Docker image to Docker Hub and replacing the image ref in the Caddy community-container. Since the changes are very basic, I don't think there will be any issues.