### PR TITLE
fixing typo

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -82,7 +82,7 @@ https://mail.{\$NC_DOMAIN}:443 {
         }
     }
 }
-https://autoconfig.{\$NC_DOMAIN}.fr:443 {
+https://autoconfig.{\$NC_DOMAIN}:443 {
     route /mail/config-v1.1.xml {
         reverse_proxy nextcloud-aio-stalwart:10003
     }
@@ -97,7 +97,7 @@ https://autoconfig.{\$NC_DOMAIN}.fr:443 {
         }
     }
 }
-https://autodiscover.{\$NC_DOMAIN}.fr:443 {
+https://autodiscover.{\$NC_DOMAIN}:443 {
     route /autodiscover/autodiscover.xml {
         reverse_proxy nextcloud-aio-stalwart:10003
     }


### PR DESCRIPTION
wrong  concat  '.fr' to  NC_DOMAIN