### PR TITLE
change custom config in nextcloud

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -313,7 +313,7 @@ fi
 
 # Import custom caddy configs that can be changed by the admin.
 # This is the legacy import to preserve compatibility with older installations.
-# This needs to be maintained on in the caddy container.
+# This needs to be maintained in the caddy container.
 mkdir -p /data/caddy-imports
 if ! grep -q "/data/caddy-imports" /Caddyfile; then
     echo 'import /data/caddy-imports/*' >> /Caddyfile
@@ -321,8 +321,8 @@ if ! grep -q "/data/caddy-imports" /Caddyfile; then
     echo "# empty file so that caddy does not print a warning" > /data/caddy-imports/empty
 fi
 
-#this is the more convenient way of maintaining the custom config in the files app of the admin
-if ! grep -q "/nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports" /Caddyfile; then
+# This is the more convenient way of maintaining the custom config in the files app of the admin
+if [ -d "/nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports" ] && ! grep -q "/nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports" /Caddyfile; then
     echo 'import /nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports/*' >> /Caddyfile
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -311,11 +311,22 @@ CADDY
     fi
 fi
 
+#import custom caddy configs that can be changed by the admin
+#this is the legacy import to preserve compatibility with older installations
+#this needs to be maintained on in the caddy container
 mkdir -p /data/caddy-imports
 if ! grep -q "/data/caddy-imports" /Caddyfile; then
     echo 'import /data/caddy-imports/*' >> /Caddyfile
     # Make sure that the caddy-imports dir is not empty
     echo "# empty file so that caddy does not print a warning" > /data/caddy-imports/empty
+fi
+
+#this is the more convenient way of maintaining the custom config in the files app of the admin
+mkdir -p /nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports
+if ! grep -q "/nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports" /Caddyfile; then
+    echo 'import /nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports/*' >> /Caddyfile
+    # Make sure that the caddy-imports dir is not empty
+    echo "# empty file so that caddy does not print a warning" > /nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports
 fi
 
 if [ "$FILTER_SET" = 1 ] && [ "$FILE_THERE" = 1 ]; then

--- a/start.sh
+++ b/start.sh
@@ -324,8 +324,6 @@ fi
 #this is the more convenient way of maintaining the custom config in the files app of the admin
 if ! grep -q "/nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports" /Caddyfile; then
     echo 'import /nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports/*' >> /Caddyfile
-    # Make sure that the caddy-imports dir is not empty
-    echo "# empty file so that caddy does not print a warning" > /nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports
 fi
 
 if [ "$FILTER_SET" = 1 ] && [ "$FILE_THERE" = 1 ]; then

--- a/start.sh
+++ b/start.sh
@@ -322,7 +322,6 @@ if ! grep -q "/data/caddy-imports" /Caddyfile; then
 fi
 
 #this is the more convenient way of maintaining the custom config in the files app of the admin
-mkdir -p /nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports
 if ! grep -q "/nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports" /Caddyfile; then
     echo 'import /nextcloud/admin/files/nextcloud-aio-caddy/caddy-imports/*' >> /Caddyfile
     # Make sure that the caddy-imports dir is not empty

--- a/start.sh
+++ b/start.sh
@@ -311,9 +311,9 @@ CADDY
     fi
 fi
 
-#import custom caddy configs that can be changed by the admin
-#this is the legacy import to preserve compatibility with older installations
-#this needs to be maintained on in the caddy container
+# Import custom caddy configs that can be changed by the admin.
+# This is the legacy import to preserve compatibility with older installations.
+# This needs to be maintained on in the caddy container.
 mkdir -p /data/caddy-imports
 if ! grep -q "/data/caddy-imports" /Caddyfile; then
     echo 'import /data/caddy-imports/*' >> /Caddyfile


### PR DESCRIPTION
- fixes #90
- linking to https://github.com/nextcloud/all-in-one/pull/7835

Include custom caddy configs from admin's nextcloud folder `nextcloud-aio-caddy/caddy-imports` . Configuration files in the old place will still work.