### PR TITLE
Add AzuraCast support (radio.$NC_DOMAIN)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -319,6 +319,24 @@ CADDY
     fi
 fi
 
+if [ -n "$(dig A +short nextcloud-aio-azuracast)" ] && ! grep -q nextcloud-aio-azuracast /Caddyfile; then
+    cat << CADDY >> /Caddyfile
+https://radio.{\$NC_DOMAIN}:443 {
+    # import GEOFILTER
+    reverse_proxy nextcloud-aio-azuracast:8080 {
+        flush_interval -1
+    }
+
+    # TLS options
+    tls {
+        issuer acme {
+            disable_http_challenge
+        }
+    }
+}
+CADDY
+fi
+
 # Import custom caddy configs that can be changed by the admin.
 # This is the legacy import to preserve compatibility with older installations.
 # This needs to be maintained in the caddy container.

--- a/start.sh
+++ b/start.sh
@@ -323,7 +323,7 @@ if [ -n "$(dig A +short nextcloud-aio-azuracast)" ] && ! grep -q nextcloud-aio-a
     cat << CADDY >> /Caddyfile
 https://radio.{\$NC_DOMAIN}:443 {
     # import GEOFILTER
-    reverse_proxy nextcloud-aio-azuracast:8080 {
+    reverse_proxy nextcloud-aio-azuracast:10080 {
         flush_interval -1
     }
 


### PR DESCRIPTION
﻿## Add AzuraCast support

This PR adds support for the [AzuraCast community container](https://github.com/nextcloud/all-in-one/tree/main/community-containers/azuracast) by configuring `radio.$NC_DOMAIN` as a reverse proxy to AzuraCast's internal nginx (port 8080).

The `flush_interval -1` directive is required for SSE (Server-Sent Events) and WebSocket support used by AzuraCast's Centrifugo now-playing updates.

### Related PR
nextcloud/all-in-one#8176
